### PR TITLE
fix:startForegroundService()

### DIFF
--- a/src/main/java/com/marianhello/bgloc/service/LocationServiceImpl.java
+++ b/src/main/java/com/marianhello/bgloc/service/LocationServiceImpl.java
@@ -269,7 +269,7 @@ public class LocationServiceImpl extends Service implements ProviderDelegate, Lo
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent == null) {
+        if (intent == null || !containsCommand(intent)) {
             // when service was killed and restarted we will restart service
             start();
             return START_STICKY;


### PR DESCRIPTION
error:Context.startForegroundService() did not then call Service.startForeground()
start function should be called in two cases if intent is null or contains extra commands